### PR TITLE
Add generated wallpapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,32 @@
 
 NEONKEY Console is a portable hacker-style hub with neon themed UI.
 
+## Dependencies
+
+Install the required packages with:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Running
 
 ```bash
 python3 neonkey.py
 ```
+
+## Background Watchers
+
+- `USBWatcher.py` launches the console automatically when a NEONKEY USB stick is inserted.
+- `ThemeWatcher.py` applies the hacker theme while the drive is connected and restores the desktop when it is removed. Wallpapers are generated on the fly using Pillow so no binary files are stored in the repository.
+
+### Building Windows Binaries
+
+Use [PyInstaller](https://www.pyinstaller.org/) to create standalone executables:
+
+```bash
+pyinstaller --onefile USBWatcher.py
+pyinstaller --onefile ThemeWatcher.py
+```
+
+Copy the generated EXE files onto your NEONKEY USB to run the watchers without needing Python installed.

--- a/ThemeWatcher.py
+++ b/ThemeWatcher.py
@@ -1,0 +1,109 @@
+import os
+import time
+import json
+import ctypes
+import psutil
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+WINDOWS = os.name == 'nt'
+MARKER_PATH = os.path.join('NEONKEY', 'launch.flag')
+BACKUP_FILE = os.path.join(SCRIPT_DIR, 'settings_backup.json')
+HACKER_WALLPAPER = os.path.join(SCRIPT_DIR, 'hacker_wallpaper.bmp')
+DEFAULT_WALLPAPER = os.path.join(SCRIPT_DIR, 'default_wallpaper.bmp')
+
+
+def generate_wallpaper(path, theme='hacker'):
+    """Create a simple wallpaper image if it doesn't exist."""
+    if os.path.exists(path):
+        return
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError:
+        return
+    w, h = 1920, 1080
+    if theme == 'hacker':
+        img = Image.new('RGB', (w, h), 'black')
+        draw = ImageDraw.Draw(img)
+        for y in range(0, h, 40):
+            color = (0, 255, 0)
+            draw.line((0, y, w, y), fill=color)
+        for x in range(0, w, 40):
+            draw.line((x, 0, x, h), fill=(0, 100, 0))
+    else:
+        img = Image.new('RGB', (w, h), (43, 43, 43))
+    img.save(path)
+
+SPI_SETDESKWALLPAPER = 0x0014
+SPI_GETDESKWALLPAPER = 0x0073
+
+
+def list_mounts():
+    return [p.mountpoint for p in psutil.disk_partitions(all=False)]
+
+
+def find_neonkey_drive():
+    for m in list_mounts():
+        if os.path.exists(os.path.join(m, MARKER_PATH)):
+            return m
+    return None
+
+
+def get_wallpaper():
+    buf = ctypes.create_unicode_buffer(260)
+    if WINDOWS:
+        ctypes.windll.user32.SystemParametersInfoW(SPI_GETDESKWALLPAPER, 260, buf, 0)
+    return buf.value
+
+
+def set_wallpaper(path):
+    if WINDOWS:
+        ctypes.windll.user32.SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, path, 3)
+
+
+def apply_theme(drive):
+    current = get_wallpaper()
+    with open(BACKUP_FILE, 'w') as f:
+        json.dump({'wallpaper': current}, f)
+    wp = HACKER_WALLPAPER
+    generate_wallpaper(wp, 'hacker')
+    set_wallpaper(wp)
+
+
+def revert_theme():
+    if not os.path.exists(BACKUP_FILE):
+        return
+    with open(BACKUP_FILE) as f:
+        data = json.load(f)
+    if not os.path.exists(data.get('wallpaper', '')):
+        generate_wallpaper(DEFAULT_WALLPAPER, 'default')
+        wp = DEFAULT_WALLPAPER
+    else:
+        wp = data.get('wallpaper')
+    set_wallpaper(wp)
+    os.remove(BACKUP_FILE)
+
+
+def main():
+    if not WINDOWS:
+        print('ThemeWatcher is Windows only')
+        return
+    print('ThemeWatcher running...')
+    active = False
+    current_drive = None
+    while True:
+        drive = find_neonkey_drive()
+        if drive and not active:
+            apply_theme(drive)
+            active = True
+            current_drive = drive
+            print('Hacker theme applied')
+        elif not drive and active:
+            revert_theme()
+            active = False
+            current_drive = None
+            print('Theme reverted')
+        time.sleep(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/USBWatcher.py
+++ b/USBWatcher.py
@@ -1,0 +1,58 @@
+import os
+import time
+import subprocess
+import psutil
+import ctypes
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+MARKER_PATH = os.path.join('NEONKEY', 'launch.flag')
+EXECUTABLE = 'NEONKEY_Console.exe'
+SCRIPT = 'neonkey.py'
+KNOWN_LABELS = {'NEONKEY'}
+
+
+def list_drives():
+    return [p.device for p in psutil.disk_partitions(all=False)]
+
+
+def get_volume_label(drive):
+    if os.name == 'nt':
+        buf = ctypes.create_unicode_buffer(1024)
+        if ctypes.windll.kernel32.GetVolumeInformationW(ctypes.c_wchar_p(drive), buf, ctypes.sizeof(buf), None, None, None, None, 0):
+            return buf.value.strip()
+    return ''
+
+
+def launch_from_drive(drive):
+    marker = os.path.join(drive, MARKER_PATH)
+    if os.path.exists(marker) or get_volume_label(drive).upper() in KNOWN_LABELS:
+        exe = os.path.join(drive, EXECUTABLE)
+        script = os.path.join(drive, SCRIPT)
+        if os.path.exists(exe):
+            if os.name == 'nt':
+                os.startfile(exe)
+            else:
+                subprocess.Popen([exe])
+            return True
+        if os.path.exists(script):
+            cmd = ['python', script] if os.name == 'nt' else ['python3', script]
+            subprocess.Popen(cmd)
+            return True
+    return False
+
+
+def main():
+    print('USBWatcher running...')
+    known = set(list_drives())
+    while True:
+        time.sleep(2)
+        drives = set(list_drives())
+        added = drives - known
+        for d in added:
+            if launch_from_drive(d):
+                print(f'Launched NEONKEY from {d}')
+        known = drives
+
+
+if __name__ == '__main__':
+    main()

--- a/neonkey.py
+++ b/neonkey.py
@@ -11,6 +11,7 @@ class InstallDialog(QtWidgets.QDialog):
     def __init__(self):
         super().__init__()
         self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+        self.showFullScreen()
         layout = QtWidgets.QVBoxLayout(self)
         label = QtWidgets.QLabel("Install NEONKEY Console on this machine?")
         label.setAlignment(QtCore.Qt.AlignCenter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyQt5
+psutil
+Pillow


### PR DESCRIPTION
## Summary
- generate default and hacker wallpapers at runtime with Pillow
- remove binary wallpaper images
- document dependencies and new wallpaper behavior
- include a requirements file for easy setup

## Testing
- `python3 -m py_compile neonkey.py scripts/install.py USBWatcher.py ThemeWatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_684b749f7cb0832ba54afc6d01067910