### PR TITLE
Add fallback run script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ pip install -r requirements.txt
 python3 neonkey.py
 ```
 
+For a simple fallback launcher, you can use `run.py` which just invokes the
+main application. To build a Windows executable named `run.exe` run:
+
+```bash
+pyinstaller --onefile run.py
+```
+
 ## Background Watchers
 
 - `USBWatcher.py` launches the console automatically when a NEONKEY USB stick is inserted.
@@ -28,6 +35,7 @@ Use [PyInstaller](https://www.pyinstaller.org/) to create standalone executables
 ```bash
 pyinstaller --onefile USBWatcher.py
 pyinstaller --onefile ThemeWatcher.py
+pyinstaller --onefile run.py
 ```
 
 Copy the generated EXE files onto your NEONKEY USB to run the watchers without needing Python installed.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+import neonkey
+
+if __name__ == "__main__":
+    neonkey.main()


### PR DESCRIPTION
## Summary
- add `run.py` as a simple entry point for launching the app
- document how to build `run.exe` with PyInstaller

## Testing
- `python -m py_compile run.py`
- `python -m py_compile neonkey.py`
- `python -m py_compile USBWatcher.py`
- `python -m py_compile ThemeWatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_684c3e174e30832ba95924d349eb4a27